### PR TITLE
Remove ISynchronizeInvoke from the core

### DIFF
--- a/Example/2005-Example.csproj
+++ b/Example/2005-Example.csproj
@@ -125,6 +125,7 @@
     <Compile Include="ConferenceForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="IdleTime.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Example/IdleTime.cs
+++ b/Example/IdleTime.cs
@@ -14,8 +14,9 @@
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using bedrock.util;
 
-namespace bedrock.util
+namespace Example
 {
     /// <summary>
     /// TimeSpan event.

--- a/Example/MainForm.cs
+++ b/Example/MainForm.cs
@@ -195,7 +195,7 @@ namespace Example
             this.subscribePubSubToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.deletePubSubToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.psm = new jabber.connection.PubSubManager();
-            this.idler = new bedrock.util.IdleTime();
+            this.idler = new IdleTime();
             this.muc = new jabber.connection.ConferenceManager();
             this.bmm = new jabber.client.BookmarkManager();
             ((System.ComponentModel.ISupportInitialize)(this.pnlCon)).BeginInit();
@@ -641,8 +641,8 @@ namespace Example
             // idler
             //
             this.idler.InvokeControl = this;
-            this.idler.OnIdle += new bedrock.util.SpanEventHandler(this.idler_OnIdle);
-            this.idler.OnUnIdle += new bedrock.util.SpanEventHandler(this.idler_OnUnIdle);
+            this.idler.OnIdle += new SpanEventHandler(this.idler_OnIdle);
+            this.idler.OnUnIdle += new SpanEventHandler(this.idler_OnUnIdle);
             //
             // muc
             //

--- a/Example/MainForm.cs
+++ b/Example/MainForm.cs
@@ -291,7 +291,6 @@ namespace Example
             this.jc.AutoReconnect = 3F;
             this.jc.AutoStartCompression = true;
             this.jc.AutoStartTLS = true;
-            this.jc.InvokeControl = this;
             this.jc.KeepAlive = 30F;
             this.jc.LocalCertificate = null;
             this.jc.Password = null;

--- a/jabber-net.csproj
+++ b/jabber-net.csproj
@@ -192,7 +192,6 @@
     <Compile Include="bedrock\util\GetOptBase.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="bedrock\util\IdleTime.cs" />
     <Compile Include="bedrock\util\Version.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/jabber/client/JabberClient.cs
+++ b/jabber/client/JabberClient.cs
@@ -564,13 +564,7 @@ namespace jabber.client
 
             if (iq.Type == IQType.error)
             {
-                if (OnRegistered != null)
-                {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnRegistered, new object[] {this, iq});
-                    else
-                        OnRegistered(this, iq);
-                }
+                OnRegistered?.Invoke(this, iq);
             }
             else if (iq.Type == IQType.result)
             {
@@ -603,11 +597,7 @@ namespace jabber.client
                 bool res = true;
                 if (OnRegisterInfo != null)
                 {
-                    if (InvokeRequired)
-                        // Don't use CheckedInvoke, since we want this to be synchronous
-                        res = (bool)this.InvokeControl.Invoke(OnRegisterInfo, new object[] { this, r });
-                    else
-                        res = OnRegisterInfo(this, r);
+                    res = OnRegisterInfo(this, r);
                     if (xdata != null)
                     {
                         f = xdata.GetField("username");
@@ -638,13 +628,7 @@ namespace jabber.client
 
         private void OnSetRegister(object sender, IQ iq, object data)
         {
-            if (OnRegistered == null)
-                return;
-
-            if (InvokeRequired)
-                CheckedInvoke(OnRegistered, new object[] {this, iq});
-            else
-                OnRegistered(this, iq);
+            OnRegistered?.Invoke(this, iq);
         }
 
         private void OnGetAuth(object sender, IQ i, object data)
@@ -721,10 +705,7 @@ namespace jabber.client
                 Presence p = tag as Presence;
                 if (p != null)
                 {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnPresence, new object[] {this, p});
-                    else
-                        OnPresence(this, p);
+                    OnPresence(this, p);
                     return;
                 }
             }
@@ -733,10 +714,7 @@ namespace jabber.client
                 Message m = tag as Message;
                 if (m != null)
                 {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnMessage, new object[] {this, m});
-                    else
-                        OnMessage(this, m);
+                    OnMessage(this, m);
                     return;
                 }
             }
@@ -744,10 +722,7 @@ namespace jabber.client
             IQ i = tag as IQ;
             if (i != null)
             {
-                if (InvokeRequired)
-                    CheckedInvoke(new IQHandler(FireOnIQ) , new object[] { this, i });
-                else
-                    FireOnIQ(this, i);
+                FireOnIQ(this, i);
                 return;
             }
         }
@@ -779,10 +754,7 @@ namespace jabber.client
         {
             if (OnAuthError != null)
             {
-                if (InvokeRequired)
-                    CheckedInvoke(OnAuthError, new object[] { this, i });
-                else
-                    OnAuthError(this, i);
+                OnAuthError(this, i);
             }
             else
             {
@@ -808,10 +780,7 @@ namespace jabber.client
 
             if (OnLoginRequired != null)
             {
-                if (InvokeRequired)
-                    CheckedInvoke(OnLoginRequired, new object[] { this });
-                else
-                    OnLoginRequired(this);
+                OnLoginRequired(this);
             }
             else
             {

--- a/jabber/connection/ConferenceManager.cs
+++ b/jabber/connection/ConferenceManager.cs
@@ -14,8 +14,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-
 using bedrock.util;
 using jabber.protocol;
 using jabber.protocol.client;
@@ -819,10 +817,6 @@ namespace jabber.connection
 
         private void ConfigForm(object sender, IQ iq, object context)
         {
-            // We should always be on the GUI thread.
-            // XmppStream should invoke before calling OnProtocol in the Tracker.
-            Debug.Assert((m_manager.Stream.InvokeControl == null) || (!m_manager.Stream.InvokeControl.InvokeRequired));
-
             IQ resp = OnRoomConfig(this, iq);
             if (resp == null)
             {

--- a/jabber/server/JabberService.cs
+++ b/jabber/server/JabberService.cs
@@ -352,10 +352,7 @@ namespace jabber.server
                 Route route = tag as Route;
                 if (route != null)
                 {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnRoute, new object[] {this, route});
-                    else
-                        OnRoute(this, route);
+                    OnRoute(this, route);
                 }
             }
             // TODO: add XdbTracker stuff
@@ -364,10 +361,7 @@ namespace jabber.server
                 Xdb xdb = tag as Xdb;
                 if (xdb != null)
                 {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnXdb, new object[] {this, xdb});
-                    else
-                        OnXdb(this, xdb);
+                    OnXdb(this, xdb);
                 }
             }
             if (OnLog != null)
@@ -375,10 +369,7 @@ namespace jabber.server
                 Log log = tag as Log;
                 if (log != null)
                 {
-                    if (InvokeRequired)
-                        CheckedInvoke(OnLog, new object[] {this, log});
-                    else
-                        OnLog(this, log);
+                    OnLog(this, log);
                 }
             }
         }


### PR DESCRIPTION
Close #5.

Instead of removing `ISynchronizeInvoke` from `IdleTime`, it was just removed to the `Example` project.
