### PR TITLE
NullReferenceException occurring in HttpStanzaStream.OnRead

### DIFF
--- a/jabber/connection/HttpStanzaStream.cs
+++ b/jabber/connection/HttpStanzaStream.cs
@@ -271,6 +271,8 @@ namespace jabber.connection
         {
             Debug.Assert(m_listener != null);
             Debug.Assert(m_elements != null);
+            if (m_listener == null || m_elements == null)
+                return false;
             m_listener.BytesRead(buf, offset, length);
             m_elements.Push(buf, offset, length);
             return true;


### PR DESCRIPTION
Added null checks. This prevents a null reference exception(NRE) from occurring during a network disruption (e.g. client loses internet connection). 

Without this fix, my windows service client crashes when I disconnect from the internet or when I lose connection for whatever reason to the XMPP server even for a brief period of time. I wrapped all jabber-net event handlers in my client code in try/catches but still unable to catch the NRE. I tried a few other things to try to catch it, but this fix is the only thing that worked for me.