### PR TITLE
Handle exception on socket connection

### DIFF
--- a/src/JabberNet/bedrock/net/AsyncSocket.cs
+++ b/src/JabberNet/bedrock/net/AsyncSocket.cs
@@ -805,8 +805,7 @@ namespace JabberNet.bedrock.net
                         }
                         catch (Exception e)
                         {
-                            FireError(e);
-                            AsyncClose();
+                            CloseWithError(e);
                             return;
                         }
                     }
@@ -818,15 +817,22 @@ namespace JabberNet.bedrock.net
                     }
                     catch (Exception ex)
                     {
-                        FireError(new AsyncSocketConnectionException($"An error occurred while connecting: {ex.Message}"));
-                        AsyncClose();
+                        CloseWithError(
+                            new AsyncSocketConnectionException(
+                                $"An error occurred while connecting: {ex.Message}",
+                                ex));
                     }
                 }
                 else
                 {
-                    FireError(new AsyncSocketConnectionException("could not connect"));
-                    AsyncClose();
+                    CloseWithError(new AsyncSocketConnectionException("could not connect"));
                 }
+            }
+
+            void CloseWithError(Exception error)
+            {
+                FireError(error);
+                AsyncClose();
             }
         }
 

--- a/src/JabberNet/bedrock/net/AsyncSocket.cs
+++ b/src/JabberNet/bedrock/net/AsyncSocket.cs
@@ -812,7 +812,15 @@ namespace JabberNet.bedrock.net
                     }
 
                     State = SocketState.Connected;
-                    m_listener.OnConnect(this);
+                    try
+                    {
+                        m_listener.OnConnect(this);
+                    }
+                    catch (Exception ex)
+                    {
+                        FireError(new AsyncSocketConnectionException($"An error occurred while connecting: {ex.Message}"));
+                        AsyncClose();
+                    }
                 }
                 else
                 {

--- a/src/JabberNet/bedrock/net/BaseSocket.cs
+++ b/src/JabberNet/bedrock/net/BaseSocket.cs
@@ -12,6 +12,7 @@
  * See licenses/Jabber-Net_LGPLv3.txt for details.
  * --------------------------------------------------------------------------*/
 
+using System;
 using System.Diagnostics;
 
 namespace JabberNet.bedrock.net
@@ -19,7 +20,7 @@ namespace JabberNet.bedrock.net
     /// <summary>
     /// Base class for AsyncSocket and proxies for AsyncSocket
     /// </summary>
-    public abstract class BaseSocket
+    public abstract class BaseSocket : IDisposable
     {
         /// <summary>
         /// Identity of the host we're connecting to.  Used for SSL
@@ -126,7 +127,7 @@ namespace JabberNet.bedrock.net
         /// Returns true if the socket is connected.
         ///</summary>
         public abstract bool Connected
-        { 
+        {
             get;
         }
 
@@ -175,5 +176,8 @@ namespace JabberNet.bedrock.net
         /// from GotData.  Attempts to do a shutdown() first.
         /// </summary>
         public abstract void Close();
+
+        /// <inheritdoc />
+        public void Dispose() => Close();
     }
 }


### PR DESCRIPTION
The SslStream.RemoteCertificate property accessed by SocketStanzaStream.OnConnect can throw exceptions e.g. handshake failed due to unexpected exception. 

As ExecuteConnect is run async, this can cause the Jabber client to crash.

I've added a simple try ... catch to handle such errors.