### PR TITLE
Deprecate the project

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,11 @@
 Jabber-Net [![NuGet][nuget-badge]][nuget] [![Appveyor build][appveyor-badge]][appveyor] [![Travis build][travis-badge]][travis]
 ==========
 
+⚠ This project is **deprecated**. Please use other XMPP libraries for .NET:
+- [Ubiety.Xmpp.Core](https://github.com/ubiety/Ubiety.Xmpp.Core)
+- [SharpXMPP](https://github.com/vitalyster/SharpXMPP/) (maintained by a former 
+  maintainer of Jabber-Net)
+
 Jabber-Net is a set of .NET classes for sending and receiving Extensible
 Messaging and Presence Protocol (XMPP), also known as the Jabber. Client
 connections, server component connections, presence, service discovery, and the

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,10 @@
 Jabber-Net [![NuGet][nuget-badge]][nuget] [![Appveyor build][appveyor-badge]][appveyor] [![Travis build][travis-badge]][travis]
 ==========
 
-⚠ This project is **deprecated**. Please use other XMPP libraries for .NET:
+⚠ This project is **deprecated**, reasons are listed in #110. Please use other
+XMPP libraries for .NET:
 - [Ubiety.Xmpp.Core](https://github.com/ubiety/Ubiety.Xmpp.Core)
-- [SharpXMPP](https://github.com/vitalyster/SharpXMPP/) (maintained by a former 
+- [SharpXMPP](https://github.com/vitalyster/SharpXMPP/) (maintained by a former
   maintainer of Jabber-Net)
 
 Jabber-Net is a set of .NET classes for sending and receiving Extensible

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,9 @@
 Jabber-Net [![NuGet][nuget-badge]][nuget] [![Appveyor build][appveyor-badge]][appveyor] [![Travis build][travis-badge]][travis]
 ==========
 
-⚠ This project is **deprecated**, reasons are listed in #110. Please use other
-XMPP libraries for .NET:
+⚠ This project is **deprecated**, reasons are listed in
+[#110](https://github.com/ForNeVeR/Jabber-Net/pull/110). Please use other XMPP
+libraries for .NET:
 - [Ubiety.Xmpp.Core](https://github.com/ubiety/Ubiety.Xmpp.Core)
 - [SharpXMPP](https://github.com/vitalyster/SharpXMPP/) (maintained by a former
   maintainer of Jabber-Net)


### PR DESCRIPTION
I have multiple reasons for that:
1. The state of the code base is far from ideal: there're multiple known race conditions (#95, #99) that are very hard to reproduce and fix. Additional challenge would be fixing them without breaking the existing API.
2. I have very little free resources to maintain such a huge library (including the Windows Forms support, .NET Core-unfriendly code etc. etc.)
3. I personally have little trust to copyleft licenses (even LGPLv3), and Jabber-Net, unfortunately, uses such license.

Sorry, everyone, but I give up on any efforts to drive the project forward. If someone else wants to maintain the project, I may transfer it or provide a helping hand.

Feel free to contact me if you're interested in project maintainership.